### PR TITLE
Remove app->shutdown for Laravel 5 support

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -28,12 +28,6 @@ class RollbarServiceProvider extends ServiceProvider {
             $app['rollbar.handler']->log($level, $message, $context);
         });
 
-        // Register Laravel shutdown function
-        $this->app->shutdown(function() use ($app)
-        {
-            $app['rollbar.client']->flush();
-        });
-
         // Register PHP shutdown function
         register_shutdown_function(function() use ($app)
         {


### PR DESCRIPTION
`shutdown` was removed in Laravel 5 from `Illuminate\Foundation\Application`. Only need to use PHP's `register_shutdown_function` now.