### PR TITLE
Change to long array syntax

### DIFF
--- a/src/RollbarLogHandler.php
+++ b/src/RollbarLogHandler.php
@@ -83,7 +83,7 @@ class RollbarLogHandler {
         {
             if (empty($this->rollbar->person) or ! is_array($this->rollbar->person))
             {
-                $this->rollbar->person = [];
+                $this->rollbar->person = array();
             }
 
             // Merge person context.


### PR DESCRIPTION
The package does not currently work on PHP 5.3 as the composer.json indicates it should. This changes a usage of short array syntax.