### PR TITLE
Added possibility to set environment in config

### DIFF
--- a/src/RollbarLogHandler.php
+++ b/src/RollbarLogHandler.php
@@ -40,7 +40,7 @@ class RollbarLogHandler {
         $this->level = $this->parseLevel($level ?: 'debug');
 
         // Set Laravel information
-        $this->rollbar->environment = $this->app->environment();
+        $this->rollbar->environment = $this->app['config']->get('services.rollbar.environment', $this->app->environment());
         $this->rollbar->root = base_path();
     }
 


### PR DESCRIPTION
This PR adds the possibility to set the environment value in the config file. If no environment value is set, the default app environment is used, making this PR completely backwards compatible. This fixes #10.