### PR TITLE
use specified rollbar person_fn function (updated version)

### DIFF
--- a/src/RollbarLogHandler.php
+++ b/src/RollbarLogHandler.php
@@ -88,7 +88,16 @@ class RollbarLogHandler {
                 $this->rollbar->person = $context['person'];
                 unset($context['person']);
             }
-
+            else
+            {
+                if ($this->rollbar->person_fn && is_callable($this->rollbar->person_fn)) {
+                    $data = @call_user_func($this->rollbar->person_fn);
+                    if (isset($data['id'])) {
+                        $this->rollbar->person = call_user_func($this->rollbar->person_fn);
+                    }
+                }
+            }
+            
             // Add user session information.
             if (isset($this->rollbar->person['session']))
             {


### PR DESCRIPTION
You can now assign and use person_fn from config file and use any user-defined helper function to pass person data to rollbar object.

```
'rollbar' => array(
	    'access_token' => 'XXX',
	    'person_fn' => 'get_rollbar_user',
	    'level' => 'debug'
	),
```

```php
function get_rollbar_user() {
    if (Auth::check()) {
        $user = Auth::user();
        return array(
            'id' => $user->id, // required - value is a string
            'username' => $user->fullName(), // required - value is a string
            'email' => $user->email, // optional - value is a string
        );
    }
    return null;
}
```
