### PR TITLE
Unprocessed context data is now sent to Rollbar when exceptions are logged

### DIFF
--- a/src/RollbarLogHandler.php
+++ b/src/RollbarLogHandler.php
@@ -59,7 +59,7 @@ class RollbarLogHandler {
 
         if ($message instanceof Exception)
         {
-            $this->rollbar->report_exception($message);
+            $this->rollbar->report_exception($message, $context);
         }
         else
         {


### PR DESCRIPTION
Fixes #36 