### PR TITLE
Laravel 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - mkdir -p build/logs
-  - phpunit --coverage-clover build/logs/clover.xml
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require-dev": {
         "orchestra/testbench": "^3.0",
         "mockery/mockery": "^0.9",
-        "satooshi/php-coveralls": "^1.0"
+        "satooshi/php-coveralls": "^1.0",
+        "phpunit/phpunit": "~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "orchestra/testbench": "^3.0",
         "mockery/mockery": "^0.9",
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~4.0|~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -39,7 +39,7 @@ class RollbarServiceProvider extends ServiceProvider
 
         $app = $this->app;
 
-        $this->app['RollbarNotifier'] = $this->app->share(function ($app) {
+        $this->app['RollbarNotifier'] = $this->app->singleton(function ($app) {
             // Default configuration.
             $defaults = [
                 'environment'  => $app->environment(),
@@ -59,7 +59,7 @@ class RollbarServiceProvider extends ServiceProvider
             return $rollbar;
         });
 
-        $this->app['Jenssegers\Rollbar\RollbarLogHandler'] = $this->app->share(function ($app) {
+        $this->app['Jenssegers\Rollbar\RollbarLogHandler'] = $this->app->singleton(function ($app) {
             $level = getenv('ROLLBAR_LEVEL') ?: $app['config']->get('services.rollbar.level', 'debug');
 
             return new RollbarLogHandler($app['RollbarNotifier'], $app, $level);

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -39,7 +39,7 @@ class RollbarServiceProvider extends ServiceProvider
 
         $app = $this->app;
 
-        $this->app['RollbarNotifier'] = $this->app->singleton(function ($app) {
+        $this->app->singleton('RollbarNotifier', function ($app) {
             // Default configuration.
             $defaults = [
                 'environment'  => $app->environment(),
@@ -59,7 +59,7 @@ class RollbarServiceProvider extends ServiceProvider
             return $rollbar;
         });
 
-        $this->app['Jenssegers\Rollbar\RollbarLogHandler'] = $this->app->singleton(function ($app) {
+        $this->app->singleton('Jenssegers\Rollbar\RollbarLogHandler', function ($app) {
             $level = getenv('ROLLBAR_LEVEL') ?: $app['config']->get('services.rollbar.level', 'debug');
 
             return new RollbarLogHandler($app['RollbarNotifier'], $app, $level);

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -22,7 +22,20 @@ class RollbarServiceProvider extends ServiceProvider
         $app = $this->app;
 
         // Listen to log messages.
-        $app['log']->listen(function ($level, $message, $context) use ($app) {
+        $app['log']->listen(function () use ($app) {
+            $args = func_get_args();
+
+            // Laravel 5.4 returns a MessageLogged instance only
+            if (count($args) == 1) {
+                $level = $args[0]->level;
+                $message = $args[0]->message;
+                $context = $args[0]->context;
+            } else {
+                $level = $args[0];
+                $message = $args[1];
+                $context = $args[2];
+            }
+
             $app['Jenssegers\Rollbar\RollbarLogHandler']->log($level, $message, $context);
         });
     }


### PR DESCRIPTION
The `share` method has been removed in Laravel 5.4. Documentation recommends using the `singleton` method instead.

Additionally, the log listener event returns a single argument now with a new class called `MessageLogged`.