### PR TITLE
Only throw missing token exception if handler is blocking

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -62,8 +62,9 @@ class RollbarServiceProvider extends ServiceProvider
             $config = array_merge($defaults, $app['config']->get('services.rollbar', []));
 
             $config['access_token'] = getenv('ROLLBAR_TOKEN') ?: $app['config']->get('services.rollbar.access_token');
+            $isAgentHandlerConfigured = isset($config['handler']) && $config['handler'] == 'agent';
 
-            if (empty($config['access_token'])) {
+            if (!$isAgentHandlerConfigured && empty($config['access_token'])) {
                 throw new InvalidArgumentException('Rollbar access token not configured');
             }
 


### PR DESCRIPTION
check if the agent is configured as handler and do not throw an exception if the rollbar token is not configured