### PR TITLE
Session does not support `Set`

### DIFF
--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -57,7 +57,7 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testAutomaticContext()
     {
-        $this->app->session->set('foo', 'bar');
+        $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');
         $clientMock->shouldReceive('report_message')->once()->with('Test log message', 'info', []);
@@ -77,7 +77,7 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testMergedContext()
     {
-        $this->app->session->set('foo', 'bar');
+        $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');
         $clientMock->shouldReceive('report_message')->once()->with('Test log message', 'info', [

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -57,7 +57,6 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testAutomaticContext()
     {
-        //Modified session to use put
         $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');
@@ -78,7 +77,6 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testMergedContext()
     {
-        //Modified session to use put
         $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -57,6 +57,7 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testAutomaticContext()
     {
+        //Modified session to use put
         $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');
@@ -77,6 +78,7 @@ class RollbarTest extends Orchestra\Testbench\TestCase
 
     public function testMergedContext()
     {
+        //Modified session to use put
         $this->app->session->put('foo', 'bar');
 
         $clientMock = Mockery::mock('RollbarNotifier');


### PR DESCRIPTION
Did some research and it seems that `set` is not formally supported. You're supposed to use `put`. 
https://laracasts.com/discuss/channels/laravel/a-session-error-after-updating-to-laravel-54

I've forked and modified to use `put` and then created my own CI build to test. All builds ran successfully: https://travis-ci.org/throck95/laravel-rollbar/builds/208743132