### PR TITLE
Indicating the service provider is loaded when app is booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Jenssegers\Rollbar\RollbarServiceProvider::class,
 If you only want to enable Rollbar reporting for certain environments you can conditionally load the service provider in your `AppServiceProvider`:
 
 ```php
-if ($this->app->environment('production')) {
-    $this->app->register(\Jenssegers\Rollbar\RollbarServiceProvider::class);
-}
+    public function boot()
+    {
+        if ($this->app->environment('production')) {
+            $this->app->register(\Jenssegers\Rollbar\RollbarServiceProvider::class);
+        }
+    }
 ```
 
 Configuration

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Jenssegers\Rollbar\RollbarServiceProvider::class,
 If you only want to enable Rollbar reporting for certain environments you can conditionally load the service provider in your `AppServiceProvider`:
 
 ```php
-    public function boot()
+    public function register()
     {
         if ($this->app->environment('production')) {
             $this->app->register(\Jenssegers\Rollbar\RollbarServiceProvider::class);


### PR DESCRIPTION
This PR attempts to make it clear that this portion of the configuration belongs in `boot()` and not `register()`