### PR TITLE
Use rollbar v1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": ">=5.4",
         "illuminate/support": "^4.0|^5.0",
-        "rollbar/rollbar": "~0.15"
+        "rollbar/rollbar": "~1.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.0",
+        "orchestra/testbench": "~3.0",
         "mockery/mockery": "^0.9",
         "satooshi/php-coveralls": "^1.0",
         "phpunit/phpunit": "~4.0|~5.0"

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
-use Rollbar;
-use RollbarNotifier;
+use Rollbar\Rollbar;
+use Jenssegers\Rollbar\RollbarLogHandler;
 
 class RollbarServiceProvider extends ServiceProvider
 {
@@ -52,46 +52,28 @@ class RollbarServiceProvider extends ServiceProvider
 
         $app = $this->app;
 
-        $this->app->singleton('RollbarNotifier', function ($app) {
-            // Default configuration.
+        $this->app->singleton('Rollbar\RollbarLogger', function ($app) {
+
             $defaults = [
                 'environment'  => $app->environment(),
                 'root'         => base_path(),
             ];
-
             $config = array_merge($defaults, $app['config']->get('services.rollbar', []));
-
             $config['access_token'] = getenv('ROLLBAR_TOKEN') ?: $app['config']->get('services.rollbar.access_token');
 
             if (empty($config['access_token'])) {
                 throw new InvalidArgumentException('Rollbar access token not configured');
             }
 
-            Rollbar::$instance = $rollbar = new RollbarNotifier($config);
+            \Rollbar\Rollbar::init($config);
 
-            return $rollbar;
+            return Rollbar::logger();
         });
 
         $this->app->singleton('Jenssegers\Rollbar\RollbarLogHandler', function ($app) {
             $level = getenv('ROLLBAR_LEVEL') ?: $app['config']->get('services.rollbar.level', 'debug');
 
-            return new RollbarLogHandler($app['RollbarNotifier'], $app, $level);
-        });
-
-        // Register the fatal error handler.
-        register_shutdown_function(function () use ($app) {
-            if (isset($app['RollbarNotifier'])) {
-                $app->make('RollbarNotifier');
-                Rollbar::report_fatal_error();
-            }
-        });
-
-        // If the Rollbar client was resolved, then there is a possibility that there
-        // are unsent error messages in the internal queue, so let's flush them.
-        register_shutdown_function(function () use ($app) {
-            if (isset($app['RollbarNotifier'])) {
-                $app['RollbarNotifier']->flush();
-            }
+            return new RollbarLogHandler($app['Rollbar\RollbarLogger'], $app, $level);
         });
     }
 }


### PR DESCRIPTION
- bumped rollbar version to v1.0.1
- adapted `RollbarLogHandler` and `RollbarServiceProvider` to reflect rollbar changes
- adapted tests to be green again
- adapted changes of @ArturMoczulski from https://github.com/rollbar/rollbar-php-laravel