### PR TITLE
Updates ReadMe with more detail on passing user-specific context

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,35 @@ Your other log messages will also be sent to Rollbar:
 
 ### Context informaton
 
+Rollbar allows you to send optional, user-specific data along with each instance of an error. If you choose to send that data, Rollbar requires an ID, and also permits optional `username` and `email` values. All values must be passed as trings.
+
 You can pass user information as context like this:
 
 ```php
-\Log::error('Something went wrong', [
-    'person' => ['id' => 123, 'username' => 'John Doe', 'email' => 'john@doe.com']
-]);
-```
+use Auth;
 
-Or pass some extra information:
+public function report(Exception $exception)
+{
+    if (Auth::check()) { // Ensure your user is logged in.
+        $user = Auth::User(); // Store user as a variable for improved legibility
+        if ($this->shouldReport($exception)) { // Ensure exception should be passed
+            \Log::error($exception->getMessage(), [ // Pass the specific exception message
+                'person' => [ //Pass your user details
+                    'id' => $user->id,
+                    'username' => $user->username,
+                    'email' => $user->email
+                ]
+            ]);
+        }
+    }
+    parent::report($exception); // If no authenticated user, report the exception anonymously as usual.
+}
+```
+The example above uses the `shouldReport()` function, which is defined in the parent `Illuminate\Foundation\Exceptions\Handler` class, and checks that the exception cannot be found within the `$dontReport` array at the top of your `App\Exceptions\Handler` class. Otherwise, Rollbar will log *every* exception your app throws, including validation errors, TokenMismatchExceptions, and other less useful errors.
+
+If you're using Laravel's Auth facade, don't forget to import it by including `use Auth;` at the top of your `App\Exceptions\Handler` class.
+
+Rollbar also accepts custom values:
 
 ```php
 \Log::warning('Something went wrong', [


### PR DESCRIPTION
Updates the ReadMe to include:

* How to pass user-specific data using Laravel's `Auth` facade.
* How to pass only exceptions that are not included within the user's `$dontReport` array.