### PR TITLE
Travis CI related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --dev --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - mkdir -p build/logs

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Currently, the build [is failing](https://travis-ci.org/jenssegers/laravel-rollbar/builds/253127329). This PR attempts to get in passing again and getting a few build-related things up-to-date. A working build on `master` also helps other PRs to see whether unit tests are passing.

Changes so far:
- [x] removed deprecated `--dev` flag for `composer install`
- [x] whitelisting the `src/` directory to get code coverage

Let me know if you'd like me to make further changes!