### PR TITLE
Add Laravel 6 support to composer requirements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "illuminate/support": "^4.0|^5.0",
+        "illuminate/support": "^4.0|^5.0|^6.0",
         "rollbar/rollbar": "~0.15"
     },
     "require-dev": {


### PR DESCRIPTION
The Rollbar package appears to work fine with Illuminate 6+, this minor change allows the package to be installed with Laravel 6.